### PR TITLE
Give up endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,10 @@ def get_hint():
 
     return hint.to_json(), SUCCESS
 
+@app.route("/target", methods=["GET"])
+def get_target_game():
+    return integration.get_target_game().to_json(), SUCCESS
+
 
 if __name__ == '__main__':
     app.run(debug=False, port=8080, host="0.0.0.0")

--- a/backend/dto/__init__.py
+++ b/backend/dto/__init__.py
@@ -1,3 +1,4 @@
 from .hint_response import *
 from .game_guess_response import *
 from .games_response import *
+from .game_response import *

--- a/backend/dto/game_response.py
+++ b/backend/dto/game_response.py
@@ -10,7 +10,7 @@ class GameResponse(Serializable):
         self.categories = self._make_set_serializable(game.categories)
         self.genres = self._make_set_serializable(game.genres)
         self.tags = self._make_set_serializable(game.tags)
-        self.release_date = game.release_date
+        self.release_date = game.release_date.isoformat()
 
     def _make_set_serializable(self, set_: set) -> list:
         return list(set_)

--- a/backend/dto/game_response.py
+++ b/backend/dto/game_response.py
@@ -1,0 +1,16 @@
+from .serializable import Serializable
+from logic.game import Game
+
+
+class GameResponse(Serializable):
+    def __init__(self, game: Game) -> None:
+        self.name = game.name
+        self.publishers = self._make_set_serializable(game.publishers)
+        self.developers = self._make_set_serializable(game.developers)
+        self.categories = self._make_set_serializable(game.categories)
+        self.genres = self._make_set_serializable(game.genres)
+        self.tags = self._make_set_serializable(game.tags)
+        self.release_date = game.release_date
+
+    def _make_set_serializable(self, set_: set) -> list:
+        return list(set_)

--- a/backend/integration.py
+++ b/backend/integration.py
@@ -60,7 +60,7 @@ class Integration:
         return HintResponse(hint=hint)
 
     def get_target_game(self) -> GameResponse:
-        target_game_record = self._get_or_update_game().target_game
+        target_game_record = self._get_or_update_game().get_target_game(self._get_first_index_name())
         target_game = Game.from_metadata(target_game_record[METADATA_NAME])
         return GameResponse(game=target_game)
 

--- a/backend/integration.py
+++ b/backend/integration.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from backend.dto import GameGuessResponse, HintResponse, GamesResponse
+from backend.dto import GameGuessResponse, HintResponse, GamesResponse, GameResponse
 from database.game_database import GameDatabase
 from logic.daily_target_game import DailyTargetGame
 from logic.game import Game
@@ -44,8 +44,10 @@ class Integration:
 
         return HintResponse(hint=hint)
 
-    def get_target_game():
-        pass
+    def get_target_game(self) -> GameResponse:
+        target_game_record = self._get_or_update_game().target_game
+        target_game = Game.from_metadata(target_game_record[METADATA_NAME])
+        return GameResponse(game=target_game)
 
     def _get_or_update_game(self) -> DailyTargetGame:
         if not self._game or self._game.is_expired():

--- a/backend/integration.py
+++ b/backend/integration.py
@@ -39,6 +39,9 @@ class Integration:
 
         return HintResponse(hint=hint)
 
+    def get_target_game():
+        pass
+
     def _get_or_update_game(self) -> DailyGame:
         if not self._game or self._game.is_expired():
             self._game = self._new_game()


### PR DESCRIPTION
Adds a new endpoint to the api: `/target` returning the target game to guess in such a format:
```json
{
    "categories": [
        "Shared/Split Screen Co-op",
        "Remote Play Together",
        "Single-player",
        "Steam Cloud",
        "Co-op",
        "Multi-player",
        "Shared/Split Screen",
        "Steam Achievements"
    ],
    "developers": [
        " LLC",
        "GIBBING TREE"
    ],
    "genres": [
        "Action",
        "Indie"
    ],
    "name": "MADNESS: Project Nexus",
    "publishers": [
        " LLC",
        "GIBBING TREE"
    ],
    "release_date": "2021-09-29",
    "tags": [
        "Gore",
        "Shooter",
        "Violent",
        "Hack and Slash",
        "Action",
        "Combat",
        "Gun Customization",
        "Dark",
        "Beat 'em up",
        "Local Co-Op",
        "Co-op",
        "3D",
        "Character Customization",
        "Funny",
        "Controller",
        "Blood",
        "Third-Person Shooter",
        "Atmospheric",
        "Arena Shooter",
        "Third Person"
    ]
}
```